### PR TITLE
Add chrono instead of c library

### DIFF
--- a/Logger/include/Logger/Logger.h
+++ b/Logger/include/Logger/Logger.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <set>
 #include <memory>
-#include <time.h>
+#include <chrono>
 
 enum LogLevel
 {
@@ -71,7 +71,7 @@ public:
     char            tmpBuffer_[MAXLINE_LOG];
     std::size_t     pos_;
 
-    time_t t_;
+    std::time_t t_;
     
     unsigned int    level_;
     std::string     directory_;

--- a/Logger/src/Logger.cc
+++ b/Logger/src/Logger.cc
@@ -1,11 +1,13 @@
 #include <iostream>
+
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <cstdarg>
 #include <errno.h>
 #include <sys/stat.h>
-#include <Logger/Logger.h>
+
+#include "Logger/Logger.h"
 
 static const size_t DEFAULT_LOGFILESIZE = 32 * 1024 * 1024;
 static const size_t PREFIX_LEVEL_LEN    = 6;
@@ -53,9 +55,9 @@ static bool MakeDir(const char* pDir)
     return true;
 }
 
-__thread Logger*  g_log = nullptr;
-__thread unsigned g_logLevel;
-__thread unsigned g_logDest;
+thread_local Logger*  g_log = nullptr;
+thread_local unsigned g_logLevel;
+thread_local unsigned g_logDest;
 
 Logger::Logger() : level_(0),
                    dest_(0)
@@ -95,13 +97,13 @@ bool Logger::CheckChangeFile()
 
 const std::string& Logger::MakeFileName()
 {
-    char buf[50];
-    time_t rawtime;
-    struct tm * timeinfo;
+    char buf[50]={0};
 
-    time(&rawtime);
-    timeinfo = localtime(&rawtime);
-    strftime(buf, 50, "%F.%T", timeinfo);
+    std::time_t rawtime=std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    struct std::tm timeinfo;
+
+    ::localtime_r(&rawtime,&timeinfo);
+    ::strftime(buf, 50 , "%F.%T", &timeinfo);
 
     fileName_ = directory_ + "/" + std::string(buf);
     fileName_ += ".log";


### PR DESCRIPTION
1.std::chrono 里面有功能可以代替time.h
2.`struct std::tm * timeinfo  --->  struct std::tm timeinfo`
    `timeinfo=localtime(&rawtime) ---> localtime_r(&rawtime,&timeinfo)`
    `__thread ----> local_thread`
使用不可重入函数localtime_r，增加安全性
3. `time(rawtime)  ---->  td::time_t rawtime=std::chrono::system_clock::to_time_t(std::chrono::system_clock::now())`
4. 有没有必要函数签名与tinykv保持一致
5.库的引入采取c++库在上  空格后面是c库  空格后面是本地写的头文件(一级在前 二级在后)  空格后面是第三方库